### PR TITLE
Add build support for Laptop4A

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [lpi4a, ahead, console, lpi4amain, meles]
+        model: [lpi4a, ahead, console, laptop, lpi4amain, meles]
 
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
             ls -al /usr/bin/qemu-riscv64-static
             sudo dpkg-reconfigure binfmt-support
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: qemu-riscv64-static-ci
           path: /usr/bin/qemu-riscv64-static
@@ -70,7 +70,7 @@ jobs:
                 mv ${CREATE_TARBALL} ../
               popd
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: common_revyos_rootfs
           path: ${{ env.CREATE_TARBALL }}
@@ -116,7 +116,7 @@ jobs:
               sudo apt install ./revyos-keyring_2023.06.12_all.deb
 
       - name: Download Built Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: ${{ env.ARTIFACTS_DIR }}
 
@@ -173,7 +173,7 @@ jobs:
             popd
 
       - name: 'Upload Artifact EMMC'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 30
           name: th1520-${{ env.BOARD }}-${{ env.BUILD_ID }}
@@ -183,7 +183,7 @@ jobs:
                   mkimg-th1520/SHA512SUMS
       
       - name: 'Upload Artifact SDCARD'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 30
           name: th1520-sdcard-${{ env.BOARD }}-${{ env.BUILD_ID }}
@@ -221,7 +221,7 @@ jobs:
           swap-storage: true
 
       - name: Download Built Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
 
       - name: Make Checksum file
         run: |

--- a/scripts/after_mkrootfs.sh
+++ b/scripts/after_mkrootfs.sh
@@ -18,7 +18,7 @@ after_mkrootfs()
         cp -rp addons/lpi4a-bt/rootfs/usr/local/bin/rtk_hciattach rootfs/usr/local/bin/
         cp -rp addons/etc/systemd/system/auto-hciattach.service rootfs/etc/systemd/system/
     fi
-    if [ "${BOARD}" == "${BOARD_CONSOLE4A}" ]; then
+    if [ "${BOARD}" == "${BOARD_CONSOLE4A}" ] || [ "${BOARD}" == "${BOARD_LAPTOP4A}" ]; then
         echo "console specific: Add AIC8800 Bluetooth Service"
         # Add Bluetooth firmware and service
         cp -rp addons/lpi4a-bt/rootfs/usr/local/bin/rtk_hciattach rootfs/usr/local/bin/
@@ -32,7 +32,7 @@ after_mkrootfs()
     # Install system services
     chroot "$CHROOT_TARGET" sh -c "systemctl enable pvrsrvkm"
     chroot "$CHROOT_TARGET" sh -c "systemctl enable firstboot"
-    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_CONSOLE4A}" ]; then
+    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_CONSOLE4A}" ] || [ "${BOARD}" == "${BOARD_LAPTOP4A}" ]; then
         echo "lpi4a specific: Enable auto-hciattach Service"
         chroot "$CHROOT_TARGET" sh -c "systemctl enable auto-hciattach"
     fi
@@ -43,7 +43,7 @@ after_mkrootfs()
 
     # Chromium add "--no-sandbox --use-gl=egl" flags
     # replace "Exec=/usr/bin/chromium %U" to "Exec=/usr/bin/chromium --no-sandbox --use-gl=egl %U"
-    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_AHEAD}" ] || [ "${BOARD}" == "${BOARD_MELES}" ] || [ "${BOARD}" == "${BOARD_CONSOLE4A}" ]; then
+    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_AHEAD}" ] || [ "${BOARD}" == "${BOARD_MELES}" ] || [ "${BOARD}" == "${BOARD_CONSOLE4A}" ] || [ "${BOARD}" == "${BOARD_LAPTOP4A}" ]; then
         sed -i "s/Exec=\/usr\/bin\/chromium/Exec=\/usr\/bin\/chromium --no-sandbox --use-gl=egl/gi" "$CHROOT_TARGET"/usr/share/applications/chromium.desktop
 
         # Temp add HDMI audio output on Volume control
@@ -59,7 +59,7 @@ after_mkrootfs()
     # Using on chip 2D accelerator for quicker window & menu drawing
     # Note: on Console 4A, DSI+HDMI dual screen will have problem for now because of xfce4-display-settings
     # (xfce4-display-settings can't handle rotated DSI screen + HDMI screen correctly, using xrandr or arandr is fine)
-    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_CONSOLE4A}" ] || [ "${BOARD}" == "${BOARD_AHEAD}" ] || [ "${BOARD}" == "${BOARD_MELES}" ]; then
+    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_CONSOLE4A}" ] || [ "${BOARD}" == "${BOARD_LAPTOP4A}" ] || [ "${BOARD}" == "${BOARD_AHEAD}" ] || [ "${BOARD}" == "${BOARD_MELES}" ]; then
         cat << EOF > "$CHROOT_TARGET"/usr/share/X11/xorg.conf.d/10-gc620.conf
 Section "Device"
 	Identifier "dc8200"
@@ -77,7 +77,7 @@ EOF
     fi
 
     # Setup branding related
-    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_CONSOLE4A}" ]; then
+    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_CONSOLE4A}" ] || [ "${BOARD}" == "${BOARD_LAPTOP4A}" ]; then
         chroot "$CHROOT_TARGET" sh -c "apt install -y $BRANDING "
         rm -vr "$CHROOT_TARGET"/etc/update-motd.d
         cp -rp addons/etc/update-motd.d "$CHROOT_TARGET"/etc/
@@ -143,7 +143,7 @@ EOF
     chroot "$CHROOT_TARGET" sh -c "useradd -m -s /bin/bash -G adm,cdrom,floppy,sudo,input,audio,dip,video,plugdev,netdev,bluetooth,lp debian"
     chroot "$CHROOT_TARGET" sh -c "echo 'debian:debian' | chpasswd"
 
-    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_CONSOLE4A}" ]; then
+    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_CONSOLE4A}" ] || [ "${BOARD}" == "${BOARD_LAPTOP4A}" ]; then
         echo "lpi4a specific: Add sipeed user"
         chroot "$CHROOT_TARGET" sh -c "useradd -m -s /bin/bash -G adm,cdrom,floppy,sudo,input,audio,dip,video,plugdev,netdev,bluetooth,lp sipeed"
         chroot "$CHROOT_TARGET" sh -c "echo 'sipeed:licheepi' | chpasswd"

--- a/scripts/after_mkrootfs.sh
+++ b/scripts/after_mkrootfs.sh
@@ -57,7 +57,9 @@ after_mkrootfs()
     fi
 
     # Using on chip 2D accelerator for quicker window & menu drawing
-    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_AHEAD}" ] || [ "${BOARD}" == "${BOARD_MELES}" ]; then
+    # Note: on Console 4A, DSI+HDMI dual screen will have problem for now because of xfce4-display-settings
+    # (xfce4-display-settings can't handle rotated DSI screen + HDMI screen correctly, using xrandr or arandr is fine)
+    if [ "${BOARD}" == "${BOARD_LPI4A}" ] || [ "${BOARD}" == "${BOARD_CONSOLE4A}" ] || [ "${BOARD}" == "${BOARD_AHEAD}" ] || [ "${BOARD}" == "${BOARD_MELES}" ]; then
         cat << EOF > "$CHROOT_TARGET"/usr/share/X11/xorg.conf.d/10-gc620.conf
 Section "Device"
 	Identifier "dc8200"

--- a/scripts/boards_list.sh
+++ b/scripts/boards_list.sh
@@ -3,6 +3,7 @@
 BOARD_LPI4A="lpi4a"
 BOARD_AHEAD="ahead"
 BOARD_CONSOLE4A="console"
+BOARD_LAPTOP4A="laptop"
 BOARD_LPI4A_MAINLINE="lpi4amain"
 BOARD_MELES="meles"
 
@@ -21,6 +22,8 @@ check_board_vaild()
             echo "building AHead image..."
         elif [ $BOARD == $BOARD_CONSOLE4A ]; then
             echo "building Console4A image..."
+        elif [ $BOARD == $BOARD_LAPTOP4A ]; then
+            echo "building Laptop4A image..."
         elif [ $BOARD == $BOARD_LPI4A_MAINLINE ]; then
             echo "building lpi4a mainline image..."
         elif [ $BOARD == $BOARD_MELES ]; then

--- a/scripts/packages_list.sh
+++ b/scripts/packages_list.sh
@@ -6,6 +6,7 @@ source $(pwd)/scripts/boards_list.sh
 KERNEL_lpi4a="linux-headers-5.10.113-th1520 linux-image-5.10.113-th1520 linux-perf-thead th1520-boot-firmware"
 KERNEL_ahead="linux-headers-5.10.113-ahead linux-image-5.10.113-ahead linux-perf-thead th1520-boot-firmware"
 KERNEL_console="linux-headers-5.10.113-th1520 linux-image-5.10.113-th1520 linux-perf-thead th1520-boot-firmware"
+KERNEL_laptop="linux-headers-5.10.113-th1520 linux-image-5.10.113-th1520 linux-perf-thead th1520-boot-firmware"
 KERNEL_lpi4amain="linux-headers-6.8.1-lpi4a linux-image-6.8.1-lpi4a th1520-mainline-opensbi th1520-boot-firmware"
 KERNEL_meles="linux-headers-5.10.113-th1520 linux-image-5.10.113-th1520 linux-perf-thead th1520-boot-firmware"
 KERNEL=$(eval echo '$'"KERNEL_${BOARD}")


### PR DESCRIPTION
Add build support for Laptop4A (14" plastic laptop using the same board as 7" metal laptop)
Also enable 2D accelerator on both laptop platform. 